### PR TITLE
Add support for extends option

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -31,6 +31,7 @@ module.exports = {
     'lines-between-class-members': ALLOW,
     'no-console': [WARN, { allow: ['info', 'warn', 'error'] }],
     'no-undef': ALLOW,
+    'arrow-body-style': ALLOW,
 
     /**
      * eslint-plugin-import

--- a/package.json
+++ b/package.json
@@ -42,12 +42,14 @@
     "prepublish": "yarn build:cjs && yarn build:esm"
   },
   "dependencies": {
+    "just-extend": "^4.2.1",
     "strip-bom": "^4.0.0",
     "strip-json-comments": "^3.1.1",
     "strip-json-trailing-commas": "^1.0.1"
   },
   "devDependencies": {
     "@types/jest": "^26.0.22",
+    "@types/just-extend": "^1.1.0",
     "@types/node": "^14.14.37",
     "@typescript-eslint/eslint-plugin": "^4.20.0",
     "@typescript-eslint/parser": "^4.20.0",

--- a/src/extends.ts
+++ b/src/extends.ts
@@ -1,0 +1,43 @@
+import * as path from 'path';
+import merge from 'just-extend';
+
+import { parse } from '~/parse';
+import { readFile, readFileSync } from '~/readFile';
+import { hasExtendsProp } from '~/utils';
+import type { ReadFileOptions, LoadOptions, ConfigOptions } from '~/types';
+
+interface ExtendedLoadOptions extends ReadFileOptions, LoadOptions {}
+
+export async function extendedLoad(
+  basePath: string,
+  relativePath?: string,
+  options?: ExtendedLoadOptions,
+): Promise<ConfigOptions> {
+  const trackExtendsProp = options?.extends ?? true;
+  const tsconfigPath =
+    relativePath != null ? path.join(path.dirname(basePath), relativePath) : basePath;
+  const config = parse(await readFile(tsconfigPath, options));
+  if (trackExtendsProp && hasExtendsProp(config)) {
+    const { extends: extendsProp, ...restConfig } = config;
+    const baseConfig = await extendedLoad(tsconfigPath, extendsProp, options);
+    return merge(true, baseConfig, restConfig);
+  }
+  return config;
+}
+
+export function extendedLoadSync(
+  basePath: string,
+  relativePath?: string,
+  options?: ExtendedLoadOptions,
+): ConfigOptions {
+  const trackExtendsProp = options?.extends ?? true;
+  const tsconfigPath =
+    relativePath != null ? path.join(path.dirname(basePath), relativePath) : basePath;
+  const config = parse(readFileSync(tsconfigPath, options));
+  if (trackExtendsProp && hasExtendsProp(config)) {
+    const { extends: extendsProp, ...restConfig } = config;
+    const baseConfig = extendedLoadSync(tsconfigPath, extendsProp, options);
+    return merge(true, baseConfig, restConfig);
+  }
+  return config;
+}

--- a/src/load.ts
+++ b/src/load.ts
@@ -1,33 +1,36 @@
 import { resolve, resolveSync } from '~/resolve';
 import { parse } from '~/parse';
 import { readFile, readFileSync } from '~/utils';
-import { Options } from '~/constants';
+import { Options, ConfigOptions } from '~/types';
+
+interface LoadOptions extends Options {
+  extend?: boolean;
+}
 
 interface LoadResult {
   path: string;
-  origin: string;
-  // TODO
-  config: any;
+  raw: string;
+  config: ConfigOptions;
 }
 
-export async function load(cwd: string, options?: Options): Promise<LoadResult> {
+export async function load(cwd: string, options?: LoadOptions): Promise<LoadResult> {
   const path = await resolve(cwd, options);
-  const origin = await readFile(path);
-  const config = parse(origin);
+  const raw = await readFile(path);
+  const config = parse(raw);
   return {
     path,
-    origin,
+    raw,
     config,
   };
 }
 
-export function loadSync(cwd: string, options?: Options): LoadResult {
+export function loadSync(cwd: string, options?: LoadOptions): LoadResult {
   const path = resolveSync(cwd, options);
-  const origin = readFileSync(path);
-  const config = parse(origin);
+  const raw = readFileSync(path);
+  const config = parse(raw);
   return {
     path,
-    origin,
+    raw,
     config,
   };
 }

--- a/src/load.ts
+++ b/src/load.ts
@@ -9,7 +9,7 @@ interface LoadResult {
 
 export async function load(cwd: string, options?: LoadOptions): Promise<LoadResult> {
   const path = await resolve(cwd, options);
-  const config = await extendedLoad(path);
+  const config = await extendedLoad(path, undefined, options);
   return {
     path,
     config,
@@ -18,7 +18,7 @@ export async function load(cwd: string, options?: LoadOptions): Promise<LoadResu
 
 export function loadSync(cwd: string, options?: LoadOptions): LoadResult {
   const path = resolveSync(cwd, options);
-  const config = extendedLoadSync(path);
+  const config = extendedLoadSync(path, undefined, options);
   return {
     path,
     config,

--- a/src/load.ts
+++ b/src/load.ts
@@ -1,36 +1,26 @@
 import { resolve, resolveSync } from '~/resolve';
-import { parse } from '~/parse';
-import { readFile, readFileSync } from '~/utils';
-import { Options, ConfigOptions } from '~/types';
-
-interface LoadOptions extends Options {
-  extend?: boolean;
-}
+import { extendedLoad, extendedLoadSync } from '~/extends';
+import { LoadOptions, ConfigOptions } from '~/types';
 
 interface LoadResult {
   path: string;
-  raw: string;
   config: ConfigOptions;
 }
 
 export async function load(cwd: string, options?: LoadOptions): Promise<LoadResult> {
   const path = await resolve(cwd, options);
-  const raw = await readFile(path);
-  const config = parse(raw);
+  const config = await extendedLoad(path);
   return {
     path,
-    raw,
     config,
   };
 }
 
 export function loadSync(cwd: string, options?: LoadOptions): LoadResult {
   const path = resolveSync(cwd, options);
-  const raw = readFileSync(path);
-  const config = parse(raw);
+  const config = extendedLoadSync(path);
   return {
     path,
-    raw,
     config,
   };
 }

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -1,9 +1,9 @@
 import stripBom from 'strip-bom';
 import stripJsonComments from 'strip-json-comments';
 import stripJsonTrailingCommas from 'strip-json-trailing-commas';
+import type { ConfigOptions } from '~/types';
 
-// TODO: Return type
-export function parse(jsonc: string): object {
+export function parse(jsonc: string): ConfigOptions {
   const json = stripJsonTrailingCommas(stripJsonComments(stripBom(jsonc)));
   return /^\s*$/.test(json) ? {} : JSON.parse(json);
 }

--- a/src/readFile.ts
+++ b/src/readFile.ts
@@ -1,0 +1,24 @@
+import * as fs from 'fs';
+import { promisify } from 'util';
+import type { ReadFileOptions } from '~/types';
+
+const defaultReadFileOptions: ReadFileOptions = {
+  encoding: 'utf-8',
+};
+
+export function readFile(
+  filePath: string,
+  options: ReadFileOptions = defaultReadFileOptions,
+): Promise<string> {
+  return promisify(fs.readFile)(filePath, options).then((content) =>
+    typeof content === 'string' ? content : content.toString('utf-8'),
+  );
+}
+
+export function readFileSync(
+  filePath: string,
+  options: ReadFileOptions = defaultReadFileOptions,
+): string {
+  const content = fs.readFileSync(filePath, options);
+  return typeof content !== 'string' ? content.toString('utf-8') : content;
+}

--- a/src/resolve.ts
+++ b/src/resolve.ts
@@ -1,6 +1,8 @@
 import * as path from 'path';
 import { stat, statSync, isFile, isDir, isJson } from './utils';
-import { TS_CONFIG, Options } from '~/constants';
+import { Options } from '~/types';
+
+const TS_CONFIG = 'tsconfig.json';
 
 /**
  * Resolve a configuration file, like `tsc`.

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,13 +1,26 @@
 export interface Options {
+  /**
+   * @default 'tsconfig.json'
+   */
   fileName?: string;
+
+  /**
+   * enable to search recursively parent directories.
+   * @default true
+   */
   recursive?: boolean;
 }
 
 export interface ReadFileOptions {
+  /** @default 'utf-8' */
   encoding?: BufferEncoding;
 }
 
 export interface LoadOptions extends Options {
+  /**
+   * enable to track extended tsconfig.json file.
+   * @default true
+   */
   extends?: boolean;
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,4 +3,12 @@ export interface Options {
   recursive?: boolean;
 }
 
+export interface ReadFileOptions {
+  encoding?: BufferEncoding;
+}
+
+export interface LoadOptions extends Options {
+  extends?: boolean;
+}
+
 export type ConfigOptions = object;

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,4 +3,4 @@ export interface Options {
   recursive?: boolean;
 }
 
-export const TS_CONFIG = 'tsconfig.json';
+export type ConfigOptions = object;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -53,3 +53,10 @@ export function readFileSync(
   const content = fs.readFileSync(filePath, options);
   return typeof content !== 'string' ? content.toString('utf-8') : content;
 }
+
+export function hasProp<T extends string>(
+  obj: unknown,
+  type: T,
+): obj is typeof obj & Record<T, unknown> {
+  return type != null && Object.prototype.hasOwnProperty.call(obj, type);
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,15 +1,12 @@
 import * as fs from 'fs';
 import * as path from 'path';
-import type { Stats } from 'fs';
 import { promisify } from 'util';
+import type { Stats } from 'fs';
+import type { ConfigOptions } from '~/types';
 
-interface ReadFileOptions {
-  encoding?: BufferEncoding;
+interface ConfigOptionsWithExtends extends ConfigOptions {
+  extends: string;
 }
-
-const defaultReadFileOptions: ReadFileOptions = {
-  encoding: 'utf-8',
-};
 
 export function stat(filePath: string): Promise<Stats | undefined> {
   return promisify(fs.stat)(filePath).catch(() => undefined);
@@ -37,26 +34,13 @@ export function isJson(filePath: string): boolean {
   return /\.json$/.test(path.basename(filePath));
 }
 
-export function readFile(
-  filePath: string,
-  options: ReadFileOptions = defaultReadFileOptions,
-): Promise<string> {
-  return promisify(fs.readFile)(filePath, options).then((content) =>
-    typeof content === 'string' ? content : content.toString('utf-8'),
-  );
-}
-
-export function readFileSync(
-  filePath: string,
-  options: ReadFileOptions = defaultReadFileOptions,
-): string {
-  const content = fs.readFileSync(filePath, options);
-  return typeof content !== 'string' ? content.toString('utf-8') : content;
-}
-
 export function hasProp<T extends string>(
   obj: unknown,
   type: T,
 ): obj is typeof obj & Record<T, unknown> {
   return type != null && Object.prototype.hasOwnProperty.call(obj, type);
+}
+
+export function hasExtendsProp(config: ConfigOptions): config is ConfigOptionsWithExtends {
+  return hasProp(config, 'extends') && typeof config.extends === 'string';
 }

--- a/test/fixtures/different/tsconfig.build.json
+++ b/test/fixtures/different/tsconfig.build.json
@@ -3,6 +3,7 @@
     "target": "es5",
     "module": "commonjs",
     "strict": true,
+    "noEmit": false,
     "declaration": true,
     "esModuleInterop": true,
     "skipLibCheck": true,

--- a/test/fixtures/invalid-extends/tsconfig.build.json
+++ b/test/fixtures/invalid-extends/tsconfig.build.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "declaration": true,
+  }
+}

--- a/test/fixtures/invalid-extends/tsconfig.json
+++ b/test/fixtures/invalid-extends/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "module": "commonjs",
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
+  }
+}

--- a/test/fixtures/nested/1/2/3/4/tsconfig.build.json
+++ b/test/fixtures/nested/1/2/3/4/tsconfig.build.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
+    "noEmit": false,
     "declaration": true,
   }
 }

--- a/test/fixtures/nested/1/2/tsconfig.json
+++ b/test/fixtures/nested/1/2/tsconfig.json
@@ -3,6 +3,7 @@
     "target": "es5",
     "module": "commonjs",
     "strict": true,
+    "noEmit": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true

--- a/test/fixtures/nested/1/2/tsconfig.json
+++ b/test/fixtures/nested/1/2/tsconfig.json
@@ -1,11 +1,8 @@
 {
+  "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "target": "es5",
-    "module": "commonjs",
-    "strict": true,
-    "noEmit": true,
-    "esModuleInterop": true,
-    "skipLibCheck": true,
-    "forceConsistentCasingInFileNames": true
+    "target": "ES6",
+    "module": "ESNEXT",
+    "moduleResolution": "node",
   }
 }

--- a/test/fixtures/nested/tsconfig.build.json
+++ b/test/fixtures/nested/tsconfig.build.json
@@ -1,6 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    "noEmit": false,
     "declaration": true,
   }
 }

--- a/test/fixtures/nested/tsconfig.json
+++ b/test/fixtures/nested/tsconfig.json
@@ -3,6 +3,7 @@
     "target": "es5",
     "module": "commonjs",
     "strict": true,
+    "noEmit": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true

--- a/test/fixtures/normal/tsconfig.build.json
+++ b/test/fixtures/normal/tsconfig.build.json
@@ -1,6 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    "noEmit": false,
     "declaration": true,
   }
 }

--- a/test/fixtures/normal/tsconfig.json
+++ b/test/fixtures/normal/tsconfig.json
@@ -3,6 +3,7 @@
     "target": "es5",
     "module": "commonjs",
     "strict": true,
+    "noEmit": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true

--- a/test/load.test.ts
+++ b/test/load.test.ts
@@ -198,13 +198,28 @@ describe('load', () => {
         path: relativePath('fixtures/nested/1/2/tsconfig.json'),
         config: {
           compilerOptions: {
-            target: 'es5',
-            module: 'commonjs',
+            target: 'ES6',
+            module: 'ESNEXT',
             strict: true,
             noEmit: true,
             esModuleInterop: true,
             skipLibCheck: true,
             forceConsistentCasingInFileNames: true,
+            moduleResolution: 'node',
+          },
+        },
+      });
+    });
+
+    it('cwd is specified as a directory in nested/1/2, and extends option is set to false', () => {
+      expect(load(relativePath('fixtures/nested/1/2/'), { extends: false })).resolves.toEqual({
+        path: relativePath('fixtures/nested/1/2/tsconfig.json'),
+        config: {
+          extends: '../../tsconfig.json',
+          compilerOptions: {
+            target: 'ES6',
+            module: 'ESNEXT',
+            moduleResolution: 'node',
           },
         },
       });
@@ -255,13 +270,28 @@ describe('load', () => {
         path: relativePath('fixtures/nested/1/2/tsconfig.json'),
         config: {
           compilerOptions: {
-            target: 'es5',
-            module: 'commonjs',
+            target: 'ES6',
+            module: 'ESNEXT',
             strict: true,
             noEmit: true,
             esModuleInterop: true,
             skipLibCheck: true,
             forceConsistentCasingInFileNames: true,
+            moduleResolution: 'node',
+          },
+        },
+      });
+    });
+
+    it('cwd is specified as a directory in nested/1/2/3, and extends option is set to false', () => {
+      expect(load(relativePath('fixtures/nested/1/2/3'), { extends: false })).resolves.toEqual({
+        path: relativePath('fixtures/nested/1/2/tsconfig.json'),
+        config: {
+          extends: '../../tsconfig.json',
+          compilerOptions: {
+            target: 'ES6',
+            module: 'ESNEXT',
+            moduleResolution: 'node',
           },
         },
       });
@@ -312,13 +342,28 @@ describe('load', () => {
         path: relativePath('fixtures/nested/1/2/tsconfig.json'),
         config: {
           compilerOptions: {
-            target: 'es5',
-            module: 'commonjs',
+            target: 'ES6',
+            module: 'ESNEXT',
             strict: true,
             noEmit: true,
             esModuleInterop: true,
             skipLibCheck: true,
             forceConsistentCasingInFileNames: true,
+            moduleResolution: 'node',
+          },
+        },
+      });
+    });
+
+    it('cwd is specified as a directory in nested/1/2/3/4, and extends option is set to false', () => {
+      expect(load(relativePath('fixtures/nested/1/2/3/4'), { extends: false })).resolves.toEqual({
+        path: relativePath('fixtures/nested/1/2/tsconfig.json'),
+        config: {
+          extends: '../../tsconfig.json',
+          compilerOptions: {
+            target: 'ES6',
+            module: 'ESNEXT',
+            moduleResolution: 'node',
           },
         },
       });
@@ -333,13 +378,14 @@ describe('load', () => {
         path: relativePath('fixtures/nested/1/2/3/4/tsconfig.build.json'),
         config: {
           compilerOptions: {
-            target: 'es5',
-            module: 'commonjs',
+            target: 'ES6',
+            module: 'ESNEXT',
             strict: true,
             noEmit: false,
             esModuleInterop: true,
             skipLibCheck: true,
             forceConsistentCasingInFileNames: true,
+            moduleResolution: 'node',
             declaration: true,
           },
         },
@@ -396,13 +442,33 @@ describe('load', () => {
         path: relativePath('fixtures/nested/1/2/tsconfig.json'),
         config: {
           compilerOptions: {
-            target: 'es5',
-            module: 'commonjs',
+            target: 'ES6',
+            module: 'ESNEXT',
             strict: true,
             noEmit: true,
             esModuleInterop: true,
             skipLibCheck: true,
             forceConsistentCasingInFileNames: true,
+            moduleResolution: 'node',
+          },
+        },
+      });
+    });
+
+    it('cwd is specified as a directory in nested/1/2, and extends option is set to false', () => {
+      expect(
+        load(relativePath('fixtures/nested/1/2/'), {
+          recursive: false,
+          extends: false,
+        }),
+      ).resolves.toEqual({
+        path: relativePath('fixtures/nested/1/2/tsconfig.json'),
+        config: {
+          extends: '../../tsconfig.json',
+          compilerOptions: {
+            target: 'ES6',
+            module: 'ESNEXT',
+            moduleResolution: 'node',
           },
         },
       });
@@ -468,13 +534,14 @@ describe('load', () => {
         path: relativePath('fixtures/nested/1/2/3/4/tsconfig.build.json'),
         config: {
           compilerOptions: {
-            target: 'es5',
-            module: 'commonjs',
+            target: 'ES6',
+            module: 'ESNEXT',
             strict: true,
             noEmit: false,
             esModuleInterop: true,
             skipLibCheck: true,
             forceConsistentCasingInFileNames: true,
+            moduleResolution: 'node',
             declaration: true,
           },
         },

--- a/test/load.test.ts
+++ b/test/load.test.ts
@@ -5,13 +5,14 @@ import { relativePath } from './utils';
 describe('load', () => {
   describe('normal', () => {
     it('cwd is specified as a file', () => {
-      expect(load(relativePath('fixtures/normal/tsconfig.json'))).resolves.toMatchObject({
+      expect(load(relativePath('fixtures/normal/tsconfig.json'))).resolves.toEqual({
         path: relativePath('fixtures/normal/tsconfig.json'),
         config: {
           compilerOptions: {
             target: 'es5',
             module: 'commonjs',
             strict: true,
+            noEmit: true,
             esModuleInterop: true,
             skipLibCheck: true,
             forceConsistentCasingInFileNames: true,
@@ -20,14 +21,15 @@ describe('load', () => {
       });
     });
 
-    it.skip('cwd is specified as a file with a different name', () => {
-      expect(load(relativePath('fixtures/normal/tsconfig.build.json'))).resolves.toMatchObject({
+    it('cwd is specified as a file with a different name', () => {
+      expect(load(relativePath('fixtures/normal/tsconfig.build.json'))).resolves.toEqual({
         path: relativePath('fixtures/normal/tsconfig.build.json'),
         config: {
           compilerOptions: {
             target: 'es5',
             module: 'commonjs',
             strict: true,
+            noEmit: false,
             esModuleInterop: true,
             skipLibCheck: true,
             forceConsistentCasingInFileNames: true,
@@ -42,13 +44,14 @@ describe('load', () => {
         load(relativePath('fixtures/normal'), {
           fileName: 'tsconfig.json',
         }),
-      ).resolves.toMatchObject({
+      ).resolves.toEqual({
         path: relativePath('fixtures/normal/tsconfig.json'),
         config: {
           compilerOptions: {
             target: 'es5',
             module: 'commonjs',
             strict: true,
+            noEmit: true,
             esModuleInterop: true,
             skipLibCheck: true,
             forceConsistentCasingInFileNames: true,
@@ -57,18 +60,19 @@ describe('load', () => {
       });
     });
 
-    it.skip('A different file name is specified in options', () => {
+    it('A different file name is specified in options', () => {
       expect(
         load(relativePath('fixtures/normal'), {
           fileName: 'tsconfig.build.json',
         }),
-      ).resolves.toMatchObject({
+      ).resolves.toEqual({
         path: relativePath('fixtures/normal/tsconfig.build.json'),
         config: {
           compilerOptions: {
             target: 'es5',
             module: 'commonjs',
             strict: true,
+            noEmit: false,
             esModuleInterop: true,
             skipLibCheck: true,
             forceConsistentCasingInFileNames: true,
@@ -79,13 +83,14 @@ describe('load', () => {
     });
 
     it('cwd is specified as a directory', () => {
-      expect(load(relativePath('fixtures/normal'))).resolves.toMatchObject({
+      expect(load(relativePath('fixtures/normal'))).resolves.toEqual({
         path: relativePath('fixtures/normal/tsconfig.json'),
         config: {
           compilerOptions: {
             target: 'es5',
             module: 'commonjs',
             strict: true,
+            noEmit: true,
             esModuleInterop: true,
             skipLibCheck: true,
             forceConsistentCasingInFileNames: true,
@@ -97,13 +102,14 @@ describe('load', () => {
 
   describe('set recursive option to true in a nested directory', () => {
     it('cwd is specified as a directory in nested/1', () => {
-      expect(load(relativePath('fixtures/nested/1'))).resolves.toMatchObject({
+      expect(load(relativePath('fixtures/nested/1'))).resolves.toEqual({
         path: relativePath('fixtures/nested/tsconfig.json'),
         config: {
           compilerOptions: {
             target: 'es5',
             module: 'commonjs',
             strict: true,
+            noEmit: true,
             esModuleInterop: true,
             skipLibCheck: true,
             forceConsistentCasingInFileNames: true,
@@ -112,33 +118,38 @@ describe('load', () => {
       });
     });
 
-    it.skip('A different file name is specified in options in nested/1', () => {
+    // eslint-disable-next-line @typescript-eslint/require-await
+    it('A different file name is specified in options in nested/1', async () => {
       expect(
         load(relativePath('fixtures/nested/1'), {
           fileName: 'tsconfig.build.json',
         }),
-      ).resolves.toMatchObject({
+      ).resolves.toEqual({
         path: relativePath('fixtures/nested/tsconfig.build.json'),
-        compilerOptions: {
-          target: 'es5',
-          module: 'commonjs',
-          strict: true,
-          esModuleInterop: true,
-          skipLibCheck: true,
-          forceConsistentCasingInFileNames: true,
-          declaration: true,
+        config: {
+          compilerOptions: {
+            target: 'es5',
+            module: 'commonjs',
+            strict: true,
+            noEmit: false,
+            esModuleInterop: true,
+            skipLibCheck: true,
+            forceConsistentCasingInFileNames: true,
+            declaration: true,
+          },
         },
       });
     });
 
     it('cwd is specified as a directory in nested/1/2', () => {
-      expect(load(relativePath('fixtures/nested/1/2/'))).resolves.toMatchObject({
+      expect(load(relativePath('fixtures/nested/1/2/'))).resolves.toEqual({
         path: relativePath('fixtures/nested/1/2/tsconfig.json'),
         config: {
           compilerOptions: {
             target: 'es5',
             module: 'commonjs',
             strict: true,
+            noEmit: true,
             esModuleInterop: true,
             skipLibCheck: true,
             forceConsistentCasingInFileNames: true,
@@ -147,18 +158,19 @@ describe('load', () => {
       });
     });
 
-    it.skip('A different file name is specified in options in nested/1/2', () => {
+    it('A different file name is specified in options in nested/1/2', () => {
       expect(
         load(relativePath('fixtures/nested/1/2/'), {
           fileName: 'tsconfig.build.json',
         }),
-      ).resolves.toMatchObject({
+      ).resolves.toEqual({
         path: relativePath('fixtures/nested/tsconfig.build.json'),
         config: {
           compilerOptions: {
             target: 'es5',
             module: 'commonjs',
             strict: true,
+            noEmit: false,
             esModuleInterop: true,
             skipLibCheck: true,
             forceConsistentCasingInFileNames: true,
@@ -169,13 +181,14 @@ describe('load', () => {
     });
 
     it('cwd is specified as a directory in nested/1/2/3', () => {
-      expect(load(relativePath('fixtures/nested/1/2/3'))).resolves.toMatchObject({
+      expect(load(relativePath('fixtures/nested/1/2/3'))).resolves.toEqual({
         path: relativePath('fixtures/nested/1/2/tsconfig.json'),
         config: {
           compilerOptions: {
             target: 'es5',
             module: 'commonjs',
             strict: true,
+            noEmit: true,
             esModuleInterop: true,
             skipLibCheck: true,
             forceConsistentCasingInFileNames: true,
@@ -184,18 +197,19 @@ describe('load', () => {
       });
     });
 
-    it.skip('A different file name is specified in options in nested/1/2/3', () => {
+    it('A different file name is specified in options in nested/1/2/3', () => {
       expect(
         load(relativePath('fixtures/nested/1/2/3'), {
           fileName: 'tsconfig.build.json',
         }),
-      ).resolves.toMatchObject({
+      ).resolves.toEqual({
         path: relativePath('fixtures/nested/tsconfig.build.json'),
         config: {
           compilerOptions: {
             target: 'es5',
             module: 'commonjs',
             strict: true,
+            noEmit: false,
             esModuleInterop: true,
             skipLibCheck: true,
             forceConsistentCasingInFileNames: true,
@@ -206,13 +220,14 @@ describe('load', () => {
     });
 
     it('cwd is specified as a directory in nested/1/2/3/4', () => {
-      expect(load(relativePath('fixtures/nested/1/2/3/4'))).resolves.toMatchObject({
+      expect(load(relativePath('fixtures/nested/1/2/3/4'))).resolves.toEqual({
         path: relativePath('fixtures/nested/1/2/tsconfig.json'),
         config: {
           compilerOptions: {
             target: 'es5',
             module: 'commonjs',
             strict: true,
+            noEmit: true,
             esModuleInterop: true,
             skipLibCheck: true,
             forceConsistentCasingInFileNames: true,
@@ -221,18 +236,19 @@ describe('load', () => {
       });
     });
 
-    it.skip('A different file name is specified in options in nested/1/2/3/4', () => {
+    it('A different file name is specified in options in nested/1/2/3/4', () => {
       expect(
         load(relativePath('fixtures/nested/1/2/3/4'), {
           fileName: 'tsconfig.build.json',
         }),
-      ).resolves.toMatchObject({
+      ).resolves.toEqual({
         path: relativePath('fixtures/nested/1/2/3/4/tsconfig.build.json'),
         config: {
           compilerOptions: {
             target: 'es5',
             module: 'commonjs',
             strict: true,
+            noEmit: false,
             esModuleInterop: true,
             skipLibCheck: true,
             forceConsistentCasingInFileNames: true,
@@ -260,15 +276,14 @@ describe('load', () => {
     });
 
     it('cwd is specified as a directory in nested/1/2', () => {
-      expect(
-        load(relativePath('fixtures/nested/1/2/'), { recursive: false }),
-      ).resolves.toMatchObject({
+      expect(load(relativePath('fixtures/nested/1/2/'), { recursive: false })).resolves.toEqual({
         path: relativePath('fixtures/nested/1/2/tsconfig.json'),
         config: {
           compilerOptions: {
             target: 'es5',
             module: 'commonjs',
             strict: true,
+            noEmit: true,
             esModuleInterop: true,
             skipLibCheck: true,
             forceConsistentCasingInFileNames: true,
@@ -307,19 +322,20 @@ describe('load', () => {
       );
     });
 
-    it.skip('A different file name is specified in options in nested/1/2/3/4', () => {
+    it('A different file name is specified in options in nested/1/2/3/4', () => {
       expect(
         load(relativePath('fixtures/nested/1/2/3/4'), {
           fileName: 'tsconfig.build.json',
           recursive: false,
         }),
-      ).resolves.toMatchObject({
+      ).resolves.toEqual({
         path: relativePath('fixtures/nested/1/2/3/4/tsconfig.build.json'),
         config: {
           compilerOptions: {
             target: 'es5',
             module: 'commonjs',
             strict: true,
+            noEmit: false,
             esModuleInterop: true,
             skipLibCheck: true,
             forceConsistentCasingInFileNames: true,

--- a/test/load.test.ts
+++ b/test/load.test.ts
@@ -39,6 +39,23 @@ describe('load', () => {
       });
     });
 
+    it('cwd is specified as a file with a different name, and extends option is set to false', () => {
+      expect(
+        load(relativePath('fixtures/normal/tsconfig.build.json'), {
+          extends: false,
+        }),
+      ).resolves.toEqual({
+        path: relativePath('fixtures/normal/tsconfig.build.json'),
+        config: {
+          extends: './tsconfig.json',
+          compilerOptions: {
+            noEmit: false,
+            declaration: true,
+          },
+        },
+      });
+    });
+
     it('A file name is specified in options', () => {
       expect(
         load(relativePath('fixtures/normal'), {
@@ -82,6 +99,24 @@ describe('load', () => {
       });
     });
 
+    it('A different file name is specified in options, and extends option is set to false', () => {
+      expect(
+        load(relativePath('fixtures/normal'), {
+          fileName: 'tsconfig.build.json',
+          extends: false,
+        }),
+      ).resolves.toEqual({
+        path: relativePath('fixtures/normal/tsconfig.build.json'),
+        config: {
+          extends: './tsconfig.json',
+          compilerOptions: {
+            noEmit: false,
+            declaration: true,
+          },
+        },
+      });
+    });
+
     it('cwd is specified as a directory', () => {
       expect(load(relativePath('fixtures/normal'))).resolves.toEqual({
         path: relativePath('fixtures/normal/tsconfig.json'),
@@ -118,8 +153,7 @@ describe('load', () => {
       });
     });
 
-    // eslint-disable-next-line @typescript-eslint/require-await
-    it('A different file name is specified in options in nested/1', async () => {
+    it('A different file name is specified in options in nested/1', () => {
       expect(
         load(relativePath('fixtures/nested/1'), {
           fileName: 'tsconfig.build.json',
@@ -135,6 +169,24 @@ describe('load', () => {
             esModuleInterop: true,
             skipLibCheck: true,
             forceConsistentCasingInFileNames: true,
+            declaration: true,
+          },
+        },
+      });
+    });
+
+    it('A different file name is specified in options in nested/1, and extends option is set to false', () => {
+      expect(
+        load(relativePath('fixtures/nested/1'), {
+          fileName: 'tsconfig.build.json',
+          extends: false,
+        }),
+      ).resolves.toEqual({
+        path: relativePath('fixtures/nested/tsconfig.build.json'),
+        config: {
+          extends: './tsconfig.json',
+          compilerOptions: {
+            noEmit: false,
             declaration: true,
           },
         },
@@ -180,6 +232,24 @@ describe('load', () => {
       });
     });
 
+    it('A different file name is specified in options in nested/1/2, and extends option is set to false', () => {
+      expect(
+        load(relativePath('fixtures/nested/1/2/'), {
+          fileName: 'tsconfig.build.json',
+          extends: false,
+        }),
+      ).resolves.toEqual({
+        path: relativePath('fixtures/nested/tsconfig.build.json'),
+        config: {
+          extends: './tsconfig.json',
+          compilerOptions: {
+            noEmit: false,
+            declaration: true,
+          },
+        },
+      });
+    });
+
     it('cwd is specified as a directory in nested/1/2/3', () => {
       expect(load(relativePath('fixtures/nested/1/2/3'))).resolves.toEqual({
         path: relativePath('fixtures/nested/1/2/tsconfig.json'),
@@ -213,6 +283,24 @@ describe('load', () => {
             esModuleInterop: true,
             skipLibCheck: true,
             forceConsistentCasingInFileNames: true,
+            declaration: true,
+          },
+        },
+      });
+    });
+
+    it('A different file name is specified in options in nested/1/2/3, and extends option is set to false', () => {
+      expect(
+        load(relativePath('fixtures/nested/1/2/3'), {
+          fileName: 'tsconfig.build.json',
+          extends: false,
+        }),
+      ).resolves.toEqual({
+        path: relativePath('fixtures/nested/tsconfig.build.json'),
+        config: {
+          extends: './tsconfig.json',
+          compilerOptions: {
+            noEmit: false,
             declaration: true,
           },
         },
@@ -257,6 +345,24 @@ describe('load', () => {
         },
       });
     });
+
+    it('A different file name is specified in options in nested/1/2/3/4, and extends option is set to false', () => {
+      expect(
+        load(relativePath('fixtures/nested/1/2/3/4'), {
+          fileName: 'tsconfig.build.json',
+          extends: false,
+        }),
+      ).resolves.toEqual({
+        path: relativePath('fixtures/nested/1/2/3/4/tsconfig.build.json'),
+        config: {
+          extends: '../../tsconfig.json',
+          compilerOptions: {
+            noEmit: false,
+            declaration: true,
+          },
+        },
+      });
+    });
   });
 
   describe('set recursive option to false in a nested directory', () => {
@@ -272,7 +378,17 @@ describe('load', () => {
           fileName: 'tsconfig.build.json',
           recursive: false,
         }),
-      ).rejects.toThrow(/The specified file does not exist: /);
+      ).rejects.toThrow(/^The specified file does not exist: /);
+    });
+
+    it('A different file name is specified in options in nested/1, and extends option is set to false', () => {
+      expect(
+        load(relativePath('fixtures/nested/1'), {
+          fileName: 'tsconfig.build.json',
+          recursive: false,
+          extends: false,
+        }),
+      ).rejects.toThrow(/^The specified file does not exist: /);
     });
 
     it('cwd is specified as a directory in nested/1/2', () => {
@@ -298,7 +414,17 @@ describe('load', () => {
           fileName: 'tsconfig.build.json',
           recursive: false,
         }),
-      ).rejects.toThrow(/The specified file does not exist: /);
+      ).rejects.toThrow(/^The specified file does not exist: /);
+    });
+
+    it('A different file name is specified in options in nested/1/2, and extends option is set to false', () => {
+      expect(
+        load(relativePath('fixtures/nested/1/2/'), {
+          fileName: 'tsconfig.build.json',
+          recursive: false,
+          extends: false,
+        }),
+      ).rejects.toThrow(/^The specified file does not exist: /);
     });
 
     it('cwd is specified as a directory in nested/1/2/3', () => {
@@ -313,7 +439,17 @@ describe('load', () => {
           fileName: 'tsconfig.build.json',
           recursive: false,
         }),
-      ).rejects.toThrow(/The specified file does not exist: /);
+      ).rejects.toThrow(/^The specified file does not exist: /);
+    });
+
+    it('A different file name is specified in options in nested/1/2/3, and extends option is set to false', () => {
+      expect(
+        load(relativePath('fixtures/nested/1/2/3'), {
+          fileName: 'tsconfig.build.json',
+          recursive: false,
+          extends: false,
+        }),
+      ).rejects.toThrow(/^The specified file does not exist: /);
     });
 
     it('cwd is specified as a directory in nested/1/2/3/4', () => {
@@ -344,6 +480,25 @@ describe('load', () => {
         },
       });
     });
+
+    it('A different file name is specified in options in nested/1/2/3/4, and extends option is set to false', () => {
+      expect(
+        load(relativePath('fixtures/nested/1/2/3/4'), {
+          fileName: 'tsconfig.build.json',
+          recursive: false,
+          extends: false,
+        }),
+      ).resolves.toEqual({
+        path: relativePath('fixtures/nested/1/2/3/4/tsconfig.build.json'),
+        config: {
+          extends: '../../tsconfig.json',
+          compilerOptions: {
+            noEmit: false,
+            declaration: true,
+          },
+        },
+      });
+    });
   });
 
   describe('invalid', () => {
@@ -357,14 +512,14 @@ describe('load', () => {
         load(relativePath('fixtures/normal'), {
           fileName: 'invalid-tsconfig.json',
         }),
-      ).rejects.toThrow(/Cannot find invalid-tsconfig\.json file at the specified directory: /);
+      ).rejects.toThrow(/^Cannot find invalid-tsconfig\.json file at the specified directory: /);
     });
     it('An empty file name is specified in options', () => {
       expect(
         load(relativePath('fixtures/normal'), {
           fileName: '',
         }),
-      ).rejects.toThrow(/The specified file does not exist, but a directory exists: /);
+      ).rejects.toThrow(/^The specified file does not exist, but a directory exists: /);
     });
     it('An invalid way of specifying directory in options', () => {
       expect(
@@ -372,7 +527,15 @@ describe('load', () => {
         load(relativePath('fixtures'), {
           fileName: 'normal',
         }),
-      ).rejects.toThrow(/The specified file does not exist, but a directory exists: /);
+      ).rejects.toThrow(/^The specified file does not exist, but a directory exists: /);
+    });
+
+    it('An invalid path in extends prop is specified', () => {
+      expect(() =>
+        load(relativePath('fixtures/invalid-extends'), {
+          fileName: 'tsconfig.build.json',
+        }),
+      ).rejects.toThrow(/^ENOENT: no such file or directory, open /);
     });
   });
 });

--- a/test/loadSync.test.ts
+++ b/test/loadSync.test.ts
@@ -4,116 +4,131 @@ import { relativePath } from './utils';
 describe('loadSync', () => {
   describe('normal', () => {
     it('cwd is specified as a file', () => {
-      const { path, config } = loadSync(relativePath('fixtures/normal/tsconfig.json'));
-      expect(path).toBe(relativePath('fixtures/normal/tsconfig.json'));
-      expect(config).toEqual({
-        compilerOptions: {
-          target: 'es5',
-          module: 'commonjs',
-          strict: true,
-          noEmit: true,
-          esModuleInterop: true,
-          skipLibCheck: true,
-          forceConsistentCasingInFileNames: true,
+      expect(loadSync(relativePath('fixtures/normal/tsconfig.json'))).toEqual({
+        path: relativePath('fixtures/normal/tsconfig.json'),
+        config: {
+          compilerOptions: {
+            target: 'es5',
+            module: 'commonjs',
+            strict: true,
+            noEmit: true,
+            esModuleInterop: true,
+            skipLibCheck: true,
+            forceConsistentCasingInFileNames: true,
+          },
         },
       });
     });
 
     it('cwd is specified as a file with a different name', () => {
-      const { path, config } = loadSync(relativePath('fixtures/normal/tsconfig.build.json'));
-      expect(path).toBe(relativePath('fixtures/normal/tsconfig.build.json'));
-      expect(config).toEqual({
-        compilerOptions: {
-          target: 'es5',
-          module: 'commonjs',
-          strict: true,
-          noEmit: false,
-          esModuleInterop: true,
-          skipLibCheck: true,
-          forceConsistentCasingInFileNames: true,
-          declaration: true,
+      expect(loadSync(relativePath('fixtures/normal/tsconfig.build.json'))).toEqual({
+        path: relativePath('fixtures/normal/tsconfig.build.json'),
+        config: {
+          compilerOptions: {
+            target: 'es5',
+            module: 'commonjs',
+            strict: true,
+            noEmit: false,
+            esModuleInterop: true,
+            skipLibCheck: true,
+            forceConsistentCasingInFileNames: true,
+            declaration: true,
+          },
         },
       });
     });
 
     it('cwd is specified as a file with a different name, and extends option is set to false', () => {
-      const { path, config } = loadSync(relativePath('fixtures/normal/tsconfig.build.json'), {
-        extends: false,
-      });
-      expect(path).toBe(relativePath('fixtures/normal/tsconfig.build.json'));
-      expect(config).toEqual({
-        extends: './tsconfig.json',
-        compilerOptions: {
-          noEmit: false,
-          declaration: true,
+      expect(
+        loadSync(relativePath('fixtures/normal/tsconfig.build.json'), {
+          extends: false,
+        }),
+      ).toEqual({
+        path: relativePath('fixtures/normal/tsconfig.build.json'),
+        config: {
+          extends: './tsconfig.json',
+          compilerOptions: {
+            noEmit: false,
+            declaration: true,
+          },
         },
       });
     });
 
     it('A file name is specified in options', () => {
-      const { path, config } = loadSync(relativePath('fixtures/normal'), {
-        fileName: 'tsconfig.json',
-      });
-      expect(path).toBe(relativePath('fixtures/normal/tsconfig.json'));
-      expect(config).toEqual({
-        compilerOptions: {
-          target: 'es5',
-          module: 'commonjs',
-          strict: true,
-          noEmit: true,
-          esModuleInterop: true,
-          skipLibCheck: true,
-          forceConsistentCasingInFileNames: true,
+      expect(
+        loadSync(relativePath('fixtures/normal'), {
+          fileName: 'tsconfig.json',
+        }),
+      ).toEqual({
+        path: relativePath('fixtures/normal/tsconfig.json'),
+        config: {
+          compilerOptions: {
+            target: 'es5',
+            module: 'commonjs',
+            strict: true,
+            noEmit: true,
+            esModuleInterop: true,
+            skipLibCheck: true,
+            forceConsistentCasingInFileNames: true,
+          },
         },
       });
     });
 
     it('A different file name is specified in options', () => {
-      const { path, config } = loadSync(relativePath('fixtures/normal'), {
-        fileName: 'tsconfig.build.json',
-      });
-      expect(path).toBe(relativePath('fixtures/normal/tsconfig.build.json'));
-      expect(config).toEqual({
-        compilerOptions: {
-          target: 'es5',
-          module: 'commonjs',
-          strict: true,
-          noEmit: false,
-          esModuleInterop: true,
-          skipLibCheck: true,
-          forceConsistentCasingInFileNames: true,
-          declaration: true,
+      expect(
+        loadSync(relativePath('fixtures/normal'), {
+          fileName: 'tsconfig.build.json',
+        }),
+      ).toEqual({
+        path: relativePath('fixtures/normal/tsconfig.build.json'),
+        config: {
+          compilerOptions: {
+            target: 'es5',
+            module: 'commonjs',
+            strict: true,
+            noEmit: false,
+            esModuleInterop: true,
+            skipLibCheck: true,
+            forceConsistentCasingInFileNames: true,
+            declaration: true,
+          },
         },
       });
     });
 
     it('A different file name is specified in options, and extends option is set to false', () => {
-      const { path, config } = loadSync(relativePath('fixtures/normal'), {
-        fileName: 'tsconfig.build.json',
-        extends: false,
-      });
-      expect(path).toBe(relativePath('fixtures/normal/tsconfig.build.json'));
-      expect(config).toEqual({
-        extends: './tsconfig.json',
-        compilerOptions: {
-          noEmit: false,
-          declaration: true,
+      expect(
+        loadSync(relativePath('fixtures/normal'), {
+          fileName: 'tsconfig.build.json',
+          extends: false,
+        }),
+      ).toEqual({
+        path: relativePath('fixtures/normal/tsconfig.build.json'),
+        config: {
+          extends: './tsconfig.json',
+          compilerOptions: {
+            noEmit: false,
+            declaration: true,
+          },
         },
       });
     });
 
     it('cwd is specified as a directory', () => {
-      const { path, config } = loadSync(relativePath('fixtures/normal'));
-      expect(path).toBe(relativePath('fixtures/normal/tsconfig.json'));
-      expect(config).toEqual({
-        compilerOptions: {
-          target: 'es5',
-          module: 'commonjs',
-          strict: true,
-          noEmit: true,
-          esModuleInterop: true,
-          skipLibCheck: true,
-          forceConsistentCasingInFileNames: true,
+      expect(loadSync(relativePath('fixtures/normal'))).toEqual({
+        path: relativePath('fixtures/normal/tsconfig.json'),
+        config: {
+          compilerOptions: {
+            target: 'es5',
+            module: 'commonjs',
+            strict: true,
+            noEmit: true,
+            esModuleInterop: true,
+            skipLibCheck: true,
+            forceConsistentCasingInFileNames: true,
+          },
         },
       });
     });
@@ -121,201 +136,275 @@ describe('loadSync', () => {
 
   describe('set recursive option to true in a nested directory', () => {
     it('cwd is specified as a directory in nested/1', () => {
-      const { path, config } = loadSync(relativePath('fixtures/nested/1'));
-      expect(path).toBe(relativePath('fixtures/nested/tsconfig.json'));
-      expect(config).toEqual({
-        compilerOptions: {
-          target: 'es5',
-          module: 'commonjs',
-          strict: true,
-          noEmit: true,
-          esModuleInterop: true,
-          skipLibCheck: true,
-          forceConsistentCasingInFileNames: true,
+      expect(loadSync(relativePath('fixtures/nested/1'))).toEqual({
+        path: relativePath('fixtures/nested/tsconfig.json'),
+        config: {
+          compilerOptions: {
+            target: 'es5',
+            module: 'commonjs',
+            strict: true,
+            noEmit: true,
+            esModuleInterop: true,
+            skipLibCheck: true,
+            forceConsistentCasingInFileNames: true,
+          },
         },
       });
     });
 
     it('A different file name is specified in options in nested/1', () => {
-      const { path, config } = loadSync(relativePath('fixtures/nested/1'), {
-        fileName: 'tsconfig.build.json',
-      });
-      expect(path).toBe(relativePath('fixtures/nested/tsconfig.build.json'));
-      expect(config).toEqual({
-        compilerOptions: {
-          target: 'es5',
-          module: 'commonjs',
-          strict: true,
-          noEmit: false,
-          esModuleInterop: true,
-          skipLibCheck: true,
-          forceConsistentCasingInFileNames: true,
-          declaration: true,
+      expect(
+        loadSync(relativePath('fixtures/nested/1'), {
+          fileName: 'tsconfig.build.json',
+        }),
+      ).toEqual({
+        path: relativePath('fixtures/nested/tsconfig.build.json'),
+        config: {
+          compilerOptions: {
+            target: 'es5',
+            module: 'commonjs',
+            strict: true,
+            noEmit: false,
+            esModuleInterop: true,
+            skipLibCheck: true,
+            forceConsistentCasingInFileNames: true,
+            declaration: true,
+          },
         },
       });
     });
 
     it('A different file name is specified in options in nested/1, and extends option is set to false', () => {
-      const { path, config } = loadSync(relativePath('fixtures/nested/1'), {
-        fileName: 'tsconfig.build.json',
-        extends: false,
-      });
-      expect(path).toBe(relativePath('fixtures/nested/tsconfig.build.json'));
-      expect(config).toEqual({
-        extends: './tsconfig.json',
-        compilerOptions: {
-          noEmit: false,
-          declaration: true,
+      expect(
+        loadSync(relativePath('fixtures/nested/1'), {
+          fileName: 'tsconfig.build.json',
+          extends: false,
+        }),
+      ).toEqual({
+        path: relativePath('fixtures/nested/tsconfig.build.json'),
+        config: {
+          extends: './tsconfig.json',
+          compilerOptions: {
+            noEmit: false,
+            declaration: true,
+          },
         },
       });
     });
 
     it('cwd is specified as a directory in nested/1/2', () => {
-      const { path, config } = loadSync(relativePath('fixtures/nested/1/2/'));
-      expect(path).toBe(relativePath('fixtures/nested/1/2/tsconfig.json'));
-      expect(config).toEqual({
-        compilerOptions: {
-          target: 'es5',
-          module: 'commonjs',
-          strict: true,
-          noEmit: true,
-          esModuleInterop: true,
-          skipLibCheck: true,
-          forceConsistentCasingInFileNames: true,
+      expect(loadSync(relativePath('fixtures/nested/1/2/'))).toEqual({
+        path: relativePath('fixtures/nested/1/2/tsconfig.json'),
+        config: {
+          compilerOptions: {
+            target: 'ES6',
+            module: 'ESNEXT',
+            strict: true,
+            noEmit: true,
+            esModuleInterop: true,
+            skipLibCheck: true,
+            forceConsistentCasingInFileNames: true,
+            moduleResolution: 'node',
+          },
+        },
+      });
+    });
+
+    it('cwd is specified as a directory in nested/1/2, and extends option is set to false', () => {
+      expect(loadSync(relativePath('fixtures/nested/1/2/'), { extends: false })).toEqual({
+        path: relativePath('fixtures/nested/1/2/tsconfig.json'),
+        config: {
+          extends: '../../tsconfig.json',
+          compilerOptions: {
+            target: 'ES6',
+            module: 'ESNEXT',
+            moduleResolution: 'node',
+          },
         },
       });
     });
 
     it('A different file name is specified in options in nested/1/2', () => {
-      const { path, config } = loadSync(relativePath('fixtures/nested/1/2/'), {
-        fileName: 'tsconfig.build.json',
-      });
-      expect(path).toBe(relativePath('fixtures/nested/tsconfig.build.json'));
-      expect(config).toEqual({
-        compilerOptions: {
-          target: 'es5',
-          module: 'commonjs',
-          strict: true,
-          noEmit: false,
-          esModuleInterop: true,
-          skipLibCheck: true,
-          forceConsistentCasingInFileNames: true,
-          declaration: true,
+      expect(
+        loadSync(relativePath('fixtures/nested/1/2/'), {
+          fileName: 'tsconfig.build.json',
+        }),
+      ).toEqual({
+        path: relativePath('fixtures/nested/tsconfig.build.json'),
+        config: {
+          compilerOptions: {
+            target: 'es5',
+            module: 'commonjs',
+            strict: true,
+            noEmit: false,
+            esModuleInterop: true,
+            skipLibCheck: true,
+            forceConsistentCasingInFileNames: true,
+            declaration: true,
+          },
         },
       });
     });
 
     it('A different file name is specified in options in nested/1/2, and extends option is set to false', () => {
-      const { path, config } = loadSync(relativePath('fixtures/nested/1/2/'), {
-        fileName: 'tsconfig.build.json',
-        extends: false,
-      });
-      expect(path).toBe(relativePath('fixtures/nested/tsconfig.build.json'));
-      expect(config).toEqual({
-        extends: './tsconfig.json',
-        compilerOptions: {
-          noEmit: false,
-          declaration: true,
+      expect(
+        loadSync(relativePath('fixtures/nested/1/2/'), {
+          fileName: 'tsconfig.build.json',
+          extends: false,
+        }),
+      ).toEqual({
+        path: relativePath('fixtures/nested/tsconfig.build.json'),
+        config: {
+          extends: './tsconfig.json',
+          compilerOptions: {
+            noEmit: false,
+            declaration: true,
+          },
         },
       });
     });
 
     it('cwd is specified as a directory in nested/1/2/3', () => {
-      const { path, config } = loadSync(relativePath('fixtures/nested/1/2/3'));
-      expect(path).toBe(relativePath('fixtures/nested/1/2/tsconfig.json'));
-      expect(config).toEqual({
-        compilerOptions: {
-          target: 'es5',
-          module: 'commonjs',
-          strict: true,
-          noEmit: true,
-          esModuleInterop: true,
-          skipLibCheck: true,
-          forceConsistentCasingInFileNames: true,
+      expect(loadSync(relativePath('fixtures/nested/1/2/3'))).toEqual({
+        path: relativePath('fixtures/nested/1/2/tsconfig.json'),
+        config: {
+          compilerOptions: {
+            target: 'ES6',
+            module: 'ESNEXT',
+            strict: true,
+            noEmit: true,
+            esModuleInterop: true,
+            skipLibCheck: true,
+            forceConsistentCasingInFileNames: true,
+            moduleResolution: 'node',
+          },
+        },
+      });
+    });
+
+    it('cwd is specified as a directory in nested/1/2/3, and extends option is set to false', () => {
+      expect(loadSync(relativePath('fixtures/nested/1/2/3'), { extends: false })).toEqual({
+        path: relativePath('fixtures/nested/1/2/tsconfig.json'),
+        config: {
+          extends: '../../tsconfig.json',
+          compilerOptions: {
+            target: 'ES6',
+            module: 'ESNEXT',
+            moduleResolution: 'node',
+          },
         },
       });
     });
 
     it('A different file name is specified in options in nested/1/2/3', () => {
-      const { path, config } = loadSync(relativePath('fixtures/nested/1/2/3'), {
-        fileName: 'tsconfig.build.json',
-      });
-      expect(path).toBe(relativePath('fixtures/nested/tsconfig.build.json'));
-      expect(config).toEqual({
-        compilerOptions: {
-          target: 'es5',
-          module: 'commonjs',
-          strict: true,
-          noEmit: false,
-          esModuleInterop: true,
-          skipLibCheck: true,
-          forceConsistentCasingInFileNames: true,
-          declaration: true,
+      expect(
+        loadSync(relativePath('fixtures/nested/1/2/3'), {
+          fileName: 'tsconfig.build.json',
+        }),
+      ).toEqual({
+        path: relativePath('fixtures/nested/tsconfig.build.json'),
+        config: {
+          compilerOptions: {
+            target: 'es5',
+            module: 'commonjs',
+            strict: true,
+            noEmit: false,
+            esModuleInterop: true,
+            skipLibCheck: true,
+            forceConsistentCasingInFileNames: true,
+            declaration: true,
+          },
         },
       });
     });
 
     it('A different file name is specified in options in nested/1/2/3, and extends option is set to false', () => {
-      const { path, config } = loadSync(relativePath('fixtures/nested/1/2/3'), {
-        fileName: 'tsconfig.build.json',
-        extends: false,
-      });
-      expect(path).toBe(relativePath('fixtures/nested/tsconfig.build.json'));
-      expect(config).toEqual({
-        extends: './tsconfig.json',
-        compilerOptions: {
-          noEmit: false,
-          declaration: true,
+      expect(
+        loadSync(relativePath('fixtures/nested/1/2/3'), {
+          fileName: 'tsconfig.build.json',
+          extends: false,
+        }),
+      ).toEqual({
+        path: relativePath('fixtures/nested/tsconfig.build.json'),
+        config: {
+          extends: './tsconfig.json',
+          compilerOptions: {
+            noEmit: false,
+            declaration: true,
+          },
         },
       });
     });
 
     it('cwd is specified as a directory in nested/1/2/3/4', () => {
-      const { path, config } = loadSync(relativePath('fixtures/nested/1/2/3/4'));
-      expect(path).toBe(relativePath('fixtures/nested/1/2/tsconfig.json'));
-      expect(config).toEqual({
-        compilerOptions: {
-          target: 'es5',
-          module: 'commonjs',
-          strict: true,
-          noEmit: true,
-          esModuleInterop: true,
-          skipLibCheck: true,
-          forceConsistentCasingInFileNames: true,
+      expect(loadSync(relativePath('fixtures/nested/1/2/3/4'))).toEqual({
+        path: relativePath('fixtures/nested/1/2/tsconfig.json'),
+        config: {
+          compilerOptions: {
+            target: 'ES6',
+            module: 'ESNEXT',
+            strict: true,
+            noEmit: true,
+            esModuleInterop: true,
+            skipLibCheck: true,
+            forceConsistentCasingInFileNames: true,
+            moduleResolution: 'node',
+          },
+        },
+      });
+    });
+
+    it('cwd is specified as a directory in nested/1/2/3/4, and extends option is set to false', () => {
+      expect(loadSync(relativePath('fixtures/nested/1/2/3/4'), { extends: false })).toEqual({
+        path: relativePath('fixtures/nested/1/2/tsconfig.json'),
+        config: {
+          extends: '../../tsconfig.json',
+          compilerOptions: {
+            target: 'ES6',
+            module: 'ESNEXT',
+            moduleResolution: 'node',
+          },
         },
       });
     });
 
     it('A different file name is specified in options in nested/1/2/3/4', () => {
-      const { path, config } = loadSync(relativePath('fixtures/nested/1/2/3/4'), {
-        fileName: 'tsconfig.build.json',
-      });
-      expect(path).toBe(relativePath('fixtures/nested/1/2/3/4/tsconfig.build.json'));
-      expect(config).toEqual({
-        compilerOptions: {
-          target: 'es5',
-          module: 'commonjs',
-          strict: true,
-          noEmit: false,
-          esModuleInterop: true,
-          skipLibCheck: true,
-          forceConsistentCasingInFileNames: true,
-          declaration: true,
+      expect(
+        loadSync(relativePath('fixtures/nested/1/2/3/4'), {
+          fileName: 'tsconfig.build.json',
+        }),
+      ).toEqual({
+        path: relativePath('fixtures/nested/1/2/3/4/tsconfig.build.json'),
+        config: {
+          compilerOptions: {
+            target: 'ES6',
+            module: 'ESNEXT',
+            strict: true,
+            noEmit: false,
+            esModuleInterop: true,
+            skipLibCheck: true,
+            forceConsistentCasingInFileNames: true,
+            moduleResolution: 'node',
+            declaration: true,
+          },
         },
       });
     });
 
     it('A different file name is specified in options in nested/1/2/3/4, and extends option is set to false', () => {
-      const { path, config } = loadSync(relativePath('fixtures/nested/1/2/3/4'), {
-        fileName: 'tsconfig.build.json',
-        extends: false,
-      });
-      expect(path).toBe(relativePath('fixtures/nested/1/2/3/4/tsconfig.build.json'));
-      expect(config).toEqual({
-        extends: '../../tsconfig.json',
-        compilerOptions: {
-          noEmit: false,
-          declaration: true,
+      expect(
+        loadSync(relativePath('fixtures/nested/1/2/3/4'), {
+          fileName: 'tsconfig.build.json',
+          extends: false,
+        }),
+      ).toEqual({
+        path: relativePath('fixtures/nested/1/2/3/4/tsconfig.build.json'),
+        config: {
+          extends: '../../tsconfig.json',
+          compilerOptions: {
+            noEmit: false,
+            declaration: true,
+          },
         },
       });
     });
@@ -348,17 +437,38 @@ describe('loadSync', () => {
     });
 
     it('cwd is specified as a directory in nested/1/2', () => {
-      const { path, config } = loadSync(relativePath('fixtures/nested/1/2/'), { recursive: false });
-      expect(path).toBe(relativePath('fixtures/nested/1/2/tsconfig.json'));
-      expect(config).toEqual({
-        compilerOptions: {
-          target: 'es5',
-          module: 'commonjs',
-          strict: true,
-          noEmit: true,
-          esModuleInterop: true,
-          skipLibCheck: true,
-          forceConsistentCasingInFileNames: true,
+      expect(loadSync(relativePath('fixtures/nested/1/2/'), { recursive: false })).toEqual({
+        path: relativePath('fixtures/nested/1/2/tsconfig.json'),
+        config: {
+          compilerOptions: {
+            target: 'ES6',
+            module: 'ESNEXT',
+            strict: true,
+            noEmit: true,
+            esModuleInterop: true,
+            skipLibCheck: true,
+            forceConsistentCasingInFileNames: true,
+            moduleResolution: 'node',
+          },
+        },
+      });
+    });
+
+    it('cwd is specified as a directory in nested/1/2, and extends option is set to false', () => {
+      expect(
+        loadSync(relativePath('fixtures/nested/1/2/'), {
+          recursive: false,
+          extends: false,
+        }),
+      ).toEqual({
+        path: relativePath('fixtures/nested/1/2/tsconfig.json'),
+        config: {
+          extends: '../../tsconfig.json',
+          compilerOptions: {
+            target: 'ES6',
+            module: 'ESNEXT',
+            moduleResolution: 'node',
+          },
         },
       });
     });
@@ -414,37 +524,44 @@ describe('loadSync', () => {
     });
 
     it('A different file name is specified in options in nested/1/2/3/4', () => {
-      const { path, config } = loadSync(relativePath('fixtures/nested/1/2/3/4'), {
-        fileName: 'tsconfig.build.json',
-        recursive: false,
-      });
-      expect(path).toBe(relativePath('fixtures/nested/1/2/3/4/tsconfig.build.json'));
-      expect(config).toEqual({
-        compilerOptions: {
-          target: 'es5',
-          module: 'commonjs',
-          strict: true,
-          noEmit: false,
-          esModuleInterop: true,
-          skipLibCheck: true,
-          forceConsistentCasingInFileNames: true,
-          declaration: true,
+      expect(
+        loadSync(relativePath('fixtures/nested/1/2/3/4'), {
+          fileName: 'tsconfig.build.json',
+          recursive: false,
+        }),
+      ).toEqual({
+        path: relativePath('fixtures/nested/1/2/3/4/tsconfig.build.json'),
+        config: {
+          compilerOptions: {
+            target: 'ES6',
+            module: 'ESNEXT',
+            strict: true,
+            noEmit: false,
+            esModuleInterop: true,
+            skipLibCheck: true,
+            forceConsistentCasingInFileNames: true,
+            moduleResolution: 'node',
+            declaration: true,
+          },
         },
       });
     });
 
     it('A different file name is specified in options in nested/1/2/3/4, and extends option is set to false', () => {
-      const { path, config } = loadSync(relativePath('fixtures/nested/1/2/3/4'), {
-        fileName: 'tsconfig.build.json',
-        recursive: false,
-        extends: false,
-      });
-      expect(path).toBe(relativePath('fixtures/nested/1/2/3/4/tsconfig.build.json'));
-      expect(config).toEqual({
-        extends: '../../tsconfig.json',
-        compilerOptions: {
-          noEmit: false,
-          declaration: true,
+      expect(
+        loadSync(relativePath('fixtures/nested/1/2/3/4'), {
+          fileName: 'tsconfig.build.json',
+          recursive: false,
+          extends: false,
+        }),
+      ).toEqual({
+        path: relativePath('fixtures/nested/1/2/3/4/tsconfig.build.json'),
+        config: {
+          extends: '../../tsconfig.json',
+          compilerOptions: {
+            noEmit: false,
+            declaration: true,
+          },
         },
       });
     });

--- a/test/loadSync.test.ts
+++ b/test/loadSync.test.ts
@@ -36,6 +36,20 @@ describe('loadSync', () => {
       });
     });
 
+    it('cwd is specified as a file with a different name, and extends option is set to false', () => {
+      const { path, config } = loadSync(relativePath('fixtures/normal/tsconfig.build.json'), {
+        extends: false,
+      });
+      expect(path).toBe(relativePath('fixtures/normal/tsconfig.build.json'));
+      expect(config).toEqual({
+        extends: './tsconfig.json',
+        compilerOptions: {
+          noEmit: false,
+          declaration: true,
+        },
+      });
+    });
+
     it('A file name is specified in options', () => {
       const { path, config } = loadSync(relativePath('fixtures/normal'), {
         fileName: 'tsconfig.json',
@@ -68,6 +82,21 @@ describe('loadSync', () => {
           esModuleInterop: true,
           skipLibCheck: true,
           forceConsistentCasingInFileNames: true,
+          declaration: true,
+        },
+      });
+    });
+
+    it('A different file name is specified in options, and extends option is set to false', () => {
+      const { path, config } = loadSync(relativePath('fixtures/normal'), {
+        fileName: 'tsconfig.build.json',
+        extends: false,
+      });
+      expect(path).toBe(relativePath('fixtures/normal/tsconfig.build.json'));
+      expect(config).toEqual({
+        extends: './tsconfig.json',
+        compilerOptions: {
+          noEmit: false,
           declaration: true,
         },
       });
@@ -126,6 +155,21 @@ describe('loadSync', () => {
       });
     });
 
+    it('A different file name is specified in options in nested/1, and extends option is set to false', () => {
+      const { path, config } = loadSync(relativePath('fixtures/nested/1'), {
+        fileName: 'tsconfig.build.json',
+        extends: false,
+      });
+      expect(path).toBe(relativePath('fixtures/nested/tsconfig.build.json'));
+      expect(config).toEqual({
+        extends: './tsconfig.json',
+        compilerOptions: {
+          noEmit: false,
+          declaration: true,
+        },
+      });
+    });
+
     it('cwd is specified as a directory in nested/1/2', () => {
       const { path, config } = loadSync(relativePath('fixtures/nested/1/2/'));
       expect(path).toBe(relativePath('fixtures/nested/1/2/tsconfig.json'));
@@ -156,6 +200,21 @@ describe('loadSync', () => {
           esModuleInterop: true,
           skipLibCheck: true,
           forceConsistentCasingInFileNames: true,
+          declaration: true,
+        },
+      });
+    });
+
+    it('A different file name is specified in options in nested/1/2, and extends option is set to false', () => {
+      const { path, config } = loadSync(relativePath('fixtures/nested/1/2/'), {
+        fileName: 'tsconfig.build.json',
+        extends: false,
+      });
+      expect(path).toBe(relativePath('fixtures/nested/tsconfig.build.json'));
+      expect(config).toEqual({
+        extends: './tsconfig.json',
+        compilerOptions: {
+          noEmit: false,
           declaration: true,
         },
       });
@@ -196,6 +255,21 @@ describe('loadSync', () => {
       });
     });
 
+    it('A different file name is specified in options in nested/1/2/3, and extends option is set to false', () => {
+      const { path, config } = loadSync(relativePath('fixtures/nested/1/2/3'), {
+        fileName: 'tsconfig.build.json',
+        extends: false,
+      });
+      expect(path).toBe(relativePath('fixtures/nested/tsconfig.build.json'));
+      expect(config).toEqual({
+        extends: './tsconfig.json',
+        compilerOptions: {
+          noEmit: false,
+          declaration: true,
+        },
+      });
+    });
+
     it('cwd is specified as a directory in nested/1/2/3/4', () => {
       const { path, config } = loadSync(relativePath('fixtures/nested/1/2/3/4'));
       expect(path).toBe(relativePath('fixtures/nested/1/2/tsconfig.json'));
@@ -230,6 +304,21 @@ describe('loadSync', () => {
         },
       });
     });
+
+    it('A different file name is specified in options in nested/1/2/3/4, and extends option is set to false', () => {
+      const { path, config } = loadSync(relativePath('fixtures/nested/1/2/3/4'), {
+        fileName: 'tsconfig.build.json',
+        extends: false,
+      });
+      expect(path).toBe(relativePath('fixtures/nested/1/2/3/4/tsconfig.build.json'));
+      expect(config).toEqual({
+        extends: '../../tsconfig.json',
+        compilerOptions: {
+          noEmit: false,
+          declaration: true,
+        },
+      });
+    });
   });
 
   describe('set recursive option to false in a nested directory', () => {
@@ -245,7 +334,17 @@ describe('loadSync', () => {
           fileName: 'tsconfig.build.json',
           recursive: false,
         }),
-      ).toThrow(/The specified file does not exist: /);
+      ).toThrow(/^The specified file does not exist: /);
+    });
+
+    it('A different file name is specified in options in nested/1, and extends option is set to false', () => {
+      expect(() =>
+        loadSync(relativePath('fixtures/nested/1'), {
+          fileName: 'tsconfig.build.json',
+          recursive: false,
+          extends: false,
+        }),
+      ).toThrow(/^The specified file does not exist: /);
     });
 
     it('cwd is specified as a directory in nested/1/2', () => {
@@ -270,7 +369,17 @@ describe('loadSync', () => {
           fileName: 'tsconfig.build.json',
           recursive: false,
         }),
-      ).toThrow(/The specified file does not exist: /);
+      ).toThrow(/^The specified file does not exist: /);
+    });
+
+    it('A different file name is specified in options in nested/1/2, and extends option is set to false', () => {
+      expect(() =>
+        loadSync(relativePath('fixtures/nested/1/2/'), {
+          fileName: 'tsconfig.build.json',
+          recursive: false,
+          extends: false,
+        }),
+      ).toThrow(/^The specified file does not exist: /);
     });
 
     it('cwd is specified as a directory in nested/1/2/3', () => {
@@ -285,7 +394,17 @@ describe('loadSync', () => {
           fileName: 'tsconfig.build.json',
           recursive: false,
         }),
-      ).toThrow(/The specified file does not exist: /);
+      ).toThrow(/^The specified file does not exist: /);
+    });
+
+    it('A different file name is specified in options in nested/1/2/3, and extends option is set to false', () => {
+      expect(() =>
+        loadSync(relativePath('fixtures/nested/1/2/3'), {
+          fileName: 'tsconfig.build.json',
+          recursive: false,
+          extends: false,
+        }),
+      ).toThrow(/^The specified file does not exist: /);
     });
 
     it('cwd is specified as a directory in nested/1/2/3/4', () => {
@@ -313,6 +432,22 @@ describe('loadSync', () => {
         },
       });
     });
+
+    it('A different file name is specified in options in nested/1/2/3/4, and extends option is set to false', () => {
+      const { path, config } = loadSync(relativePath('fixtures/nested/1/2/3/4'), {
+        fileName: 'tsconfig.build.json',
+        recursive: false,
+        extends: false,
+      });
+      expect(path).toBe(relativePath('fixtures/nested/1/2/3/4/tsconfig.build.json'));
+      expect(config).toEqual({
+        extends: '../../tsconfig.json',
+        compilerOptions: {
+          noEmit: false,
+          declaration: true,
+        },
+      });
+    });
   });
 
   describe('invalid', () => {
@@ -327,7 +462,7 @@ describe('loadSync', () => {
         loadSync(relativePath('fixtures/normal'), {
           fileName: 'invalid-tsconfig.json',
         }),
-      ).toThrow(/Cannot find invalid-tsconfig\.json file at the specified directory: /);
+      ).toThrow(/^Cannot find invalid-tsconfig\.json file at the specified directory: /);
     });
 
     it('An empty file name is specified in options', () => {
@@ -335,7 +470,7 @@ describe('loadSync', () => {
         loadSync(relativePath('fixtures/normal'), {
           fileName: '',
         }),
-      ).toThrow(/The specified file does not exist, but a directory exists: /);
+      ).toThrow(/^The specified file does not exist, but a directory exists: /);
     });
 
     it('An invalid way of specifying directory in options', () => {
@@ -344,7 +479,15 @@ describe('loadSync', () => {
         loadSync(relativePath('fixtures'), {
           fileName: 'normal',
         }),
-      ).toThrow(/The specified file does not exist, but a directory exists: /);
+      ).toThrow(/^The specified file does not exist, but a directory exists: /);
+    });
+
+    it('An invalid path in extends prop is specified', () => {
+      expect(() =>
+        loadSync(relativePath('fixtures/invalid-extends'), {
+          fileName: 'tsconfig.build.json',
+        }),
+      ).toThrow(/^ENOENT: no such file or directory, open /);
     });
   });
 });

--- a/test/loadSync.test.ts
+++ b/test/loadSync.test.ts
@@ -11,6 +11,7 @@ describe('loadSync', () => {
           target: 'es5',
           module: 'commonjs',
           strict: true,
+          noEmit: true,
           esModuleInterop: true,
           skipLibCheck: true,
           forceConsistentCasingInFileNames: true,
@@ -18,7 +19,7 @@ describe('loadSync', () => {
       });
     });
 
-    it.skip('cwd is specified as a file with a different name', () => {
+    it('cwd is specified as a file with a different name', () => {
       const { path, config } = loadSync(relativePath('fixtures/normal/tsconfig.build.json'));
       expect(path).toBe(relativePath('fixtures/normal/tsconfig.build.json'));
       expect(config).toEqual({
@@ -26,6 +27,7 @@ describe('loadSync', () => {
           target: 'es5',
           module: 'commonjs',
           strict: true,
+          noEmit: false,
           esModuleInterop: true,
           skipLibCheck: true,
           forceConsistentCasingInFileNames: true,
@@ -44,6 +46,7 @@ describe('loadSync', () => {
           target: 'es5',
           module: 'commonjs',
           strict: true,
+          noEmit: true,
           esModuleInterop: true,
           skipLibCheck: true,
           forceConsistentCasingInFileNames: true,
@@ -51,7 +54,7 @@ describe('loadSync', () => {
       });
     });
 
-    it.skip('A different file name is specified in options', () => {
+    it('A different file name is specified in options', () => {
       const { path, config } = loadSync(relativePath('fixtures/normal'), {
         fileName: 'tsconfig.build.json',
       });
@@ -61,6 +64,7 @@ describe('loadSync', () => {
           target: 'es5',
           module: 'commonjs',
           strict: true,
+          noEmit: false,
           esModuleInterop: true,
           skipLibCheck: true,
           forceConsistentCasingInFileNames: true,
@@ -77,6 +81,7 @@ describe('loadSync', () => {
           target: 'es5',
           module: 'commonjs',
           strict: true,
+          noEmit: true,
           esModuleInterop: true,
           skipLibCheck: true,
           forceConsistentCasingInFileNames: true,
@@ -94,6 +99,7 @@ describe('loadSync', () => {
           target: 'es5',
           module: 'commonjs',
           strict: true,
+          noEmit: true,
           esModuleInterop: true,
           skipLibCheck: true,
           forceConsistentCasingInFileNames: true,
@@ -101,7 +107,7 @@ describe('loadSync', () => {
       });
     });
 
-    it.skip('A different file name is specified in options in nested/1', () => {
+    it('A different file name is specified in options in nested/1', () => {
       const { path, config } = loadSync(relativePath('fixtures/nested/1'), {
         fileName: 'tsconfig.build.json',
       });
@@ -111,6 +117,7 @@ describe('loadSync', () => {
           target: 'es5',
           module: 'commonjs',
           strict: true,
+          noEmit: false,
           esModuleInterop: true,
           skipLibCheck: true,
           forceConsistentCasingInFileNames: true,
@@ -127,6 +134,7 @@ describe('loadSync', () => {
           target: 'es5',
           module: 'commonjs',
           strict: true,
+          noEmit: true,
           esModuleInterop: true,
           skipLibCheck: true,
           forceConsistentCasingInFileNames: true,
@@ -134,7 +142,7 @@ describe('loadSync', () => {
       });
     });
 
-    it.skip('A different file name is specified in options in nested/1/2', () => {
+    it('A different file name is specified in options in nested/1/2', () => {
       const { path, config } = loadSync(relativePath('fixtures/nested/1/2/'), {
         fileName: 'tsconfig.build.json',
       });
@@ -144,6 +152,7 @@ describe('loadSync', () => {
           target: 'es5',
           module: 'commonjs',
           strict: true,
+          noEmit: false,
           esModuleInterop: true,
           skipLibCheck: true,
           forceConsistentCasingInFileNames: true,
@@ -160,6 +169,7 @@ describe('loadSync', () => {
           target: 'es5',
           module: 'commonjs',
           strict: true,
+          noEmit: true,
           esModuleInterop: true,
           skipLibCheck: true,
           forceConsistentCasingInFileNames: true,
@@ -167,7 +177,7 @@ describe('loadSync', () => {
       });
     });
 
-    it.skip('A different file name is specified in options in nested/1/2/3', () => {
+    it('A different file name is specified in options in nested/1/2/3', () => {
       const { path, config } = loadSync(relativePath('fixtures/nested/1/2/3'), {
         fileName: 'tsconfig.build.json',
       });
@@ -177,6 +187,7 @@ describe('loadSync', () => {
           target: 'es5',
           module: 'commonjs',
           strict: true,
+          noEmit: false,
           esModuleInterop: true,
           skipLibCheck: true,
           forceConsistentCasingInFileNames: true,
@@ -193,6 +204,7 @@ describe('loadSync', () => {
           target: 'es5',
           module: 'commonjs',
           strict: true,
+          noEmit: true,
           esModuleInterop: true,
           skipLibCheck: true,
           forceConsistentCasingInFileNames: true,
@@ -200,7 +212,7 @@ describe('loadSync', () => {
       });
     });
 
-    it.skip('A different file name is specified in options in nested/1/2/3/4', () => {
+    it('A different file name is specified in options in nested/1/2/3/4', () => {
       const { path, config } = loadSync(relativePath('fixtures/nested/1/2/3/4'), {
         fileName: 'tsconfig.build.json',
       });
@@ -210,6 +222,7 @@ describe('loadSync', () => {
           target: 'es5',
           module: 'commonjs',
           strict: true,
+          noEmit: false,
           esModuleInterop: true,
           skipLibCheck: true,
           forceConsistentCasingInFileNames: true,
@@ -243,6 +256,7 @@ describe('loadSync', () => {
           target: 'es5',
           module: 'commonjs',
           strict: true,
+          noEmit: true,
           esModuleInterop: true,
           skipLibCheck: true,
           forceConsistentCasingInFileNames: true,
@@ -280,7 +294,7 @@ describe('loadSync', () => {
       );
     });
 
-    it.skip('A different file name is specified in options in nested/1/2/3/4', () => {
+    it('A different file name is specified in options in nested/1/2/3/4', () => {
       const { path, config } = loadSync(relativePath('fixtures/nested/1/2/3/4'), {
         fileName: 'tsconfig.build.json',
         recursive: false,
@@ -291,6 +305,7 @@ describe('loadSync', () => {
           target: 'es5',
           module: 'commonjs',
           strict: true,
+          noEmit: false,
           esModuleInterop: true,
           skipLibCheck: true,
           forceConsistentCasingInFileNames: true,

--- a/test/parse.test.ts
+++ b/test/parse.test.ts
@@ -186,7 +186,7 @@ describe('parse', () => {
         ],
       },
     `),
-    ).toThrow(/Unexpected token , in JSON at position/);
+    ).toThrow(/^Unexpected token , in JSON at position/);
   });
 
   it('tsconfig with missing commas', () => {
@@ -207,7 +207,7 @@ describe('parse', () => {
         ],
       },
     `),
-    ).toThrow(/Unexpected token , in JSON at position/);
+    ).toThrow(/^Unexpected token , in JSON at position/);
   });
 
   it('invalid tsconfig', () => {
@@ -228,6 +228,6 @@ describe('parse', () => {
         ],
       }
     `),
-    ).toThrow(/Unexpected string in JSON at position/);
+    ).toThrow(/^Unexpected string in JSON at position/);
   });
 });

--- a/test/resolve.test.ts
+++ b/test/resolve.test.ts
@@ -110,7 +110,7 @@ describe('resolve', () => {
           fileName: 'tsconfig.build.json',
           recursive: false,
         }),
-      ).rejects.toThrow(/The specified file does not exist: /);
+      ).rejects.toThrow(/^The specified file does not exist: /);
     });
 
     it('cwd is specified as a directory in nested/1/2', () => {
@@ -125,7 +125,7 @@ describe('resolve', () => {
           fileName: 'tsconfig.build.json',
           recursive: false,
         }),
-      ).rejects.toThrow(/The specified file does not exist: /);
+      ).rejects.toThrow(/^The specified file does not exist: /);
     });
 
     it('cwd is specified as a directory in nested/1/2/3', () => {
@@ -140,13 +140,13 @@ describe('resolve', () => {
           fileName: 'tsconfig.build.json',
           recursive: false,
         }),
-      ).rejects.toThrow(/The specified file does not exist: /);
+      ).rejects.toThrow(/^The specified file does not exist: /);
     });
 
     it('cwd is specified as a directory in nested/1/2/3/4', () => {
       expect(
         resolve(relativePath('fixtures/nested/1/2/3/4'), { recursive: false }),
-      ).rejects.toThrow(/The specified file does not exist: /);
+      ).rejects.toThrow(/^The specified file does not exist: /);
     });
 
     it('A different file name is specified in options in nested/1/2/3/4', () => {
@@ -170,14 +170,14 @@ describe('resolve', () => {
         resolve(relativePath('fixtures/normal'), {
           fileName: 'invalid-tsconfig.json',
         }),
-      ).rejects.toThrow(/Cannot find invalid-tsconfig\.json file at the specified directory: /);
+      ).rejects.toThrow(/^Cannot find invalid-tsconfig\.json file at the specified directory: /);
     });
     it('An empty file name is specified in options', () => {
       expect(
         resolve(relativePath('fixtures/normal'), {
           fileName: '',
         }),
-      ).rejects.toThrow(/The specified file does not exist, but a directory exists: /);
+      ).rejects.toThrow(/^The specified file does not exist, but a directory exists: /);
     });
     it('An invalid way of specifying directory in options', () => {
       expect(
@@ -185,7 +185,7 @@ describe('resolve', () => {
         resolve(relativePath('fixtures'), {
           fileName: 'normal',
         }),
-      ).rejects.toThrow(/The specified file does not exist, but a directory exists: /);
+      ).rejects.toThrow(/^The specified file does not exist, but a directory exists: /);
     });
   });
 });

--- a/test/resolveSync.test.ts
+++ b/test/resolveSync.test.ts
@@ -109,7 +109,7 @@ describe('resolveSync', () => {
           fileName: 'tsconfig.build.json',
           recursive: false,
         }),
-      ).toThrow(/The specified file does not exist: /);
+      ).toThrow(/^The specified file does not exist: /);
     });
 
     it('cwd is specified as a directory in nested/1/2', () => {
@@ -124,13 +124,13 @@ describe('resolveSync', () => {
           fileName: 'tsconfig.build.json',
           recursive: false,
         }),
-      ).toThrow(/The specified file does not exist: /);
+      ).toThrow(/^The specified file does not exist: /);
     });
 
     it('cwd is specified as a directory in nested/1/2/3', () => {
       expect(() =>
         resolveSync(relativePath('fixtures/nested/1/2/3'), { recursive: false }),
-      ).toThrow(/The specified file does not exist: /);
+      ).toThrow(/^The specified file does not exist: /);
     });
 
     it('A different file name is specified in options in nested/1/2/3', () => {
@@ -139,13 +139,13 @@ describe('resolveSync', () => {
           fileName: 'tsconfig.build.json',
           recursive: false,
         }),
-      ).toThrow(/The specified file does not exist: /);
+      ).toThrow(/^The specified file does not exist: /);
     });
 
     it('cwd is specified as a directory in nested/1/2/3/4', () => {
       expect(() =>
         resolveSync(relativePath('fixtures/nested/1/2/3/4'), { recursive: false }),
-      ).toThrow(/The specified file does not exist: /);
+      ).toThrow(/^The specified file does not exist: /);
     });
 
     it('A different file name is specified in options in nested/1/2/3/4', () => {
@@ -170,7 +170,7 @@ describe('resolveSync', () => {
         resolveSync(relativePath('fixtures/normal'), {
           fileName: 'invalid-tsconfig.json',
         }),
-      ).toThrow(/Cannot find invalid-tsconfig\.json file at the specified directory: /);
+      ).toThrow(/^Cannot find invalid-tsconfig\.json file at the specified directory: /);
     });
 
     it('An empty file name is specified in options', () => {
@@ -178,7 +178,7 @@ describe('resolveSync', () => {
         resolveSync(relativePath('fixtures/normal'), {
           fileName: '',
         }),
-      ).toThrow(/The specified file does not exist, but a directory exists: /);
+      ).toThrow(/^The specified file does not exist, but a directory exists: /);
     });
 
     it('An invalid way of specifying directory in options', () => {
@@ -187,7 +187,7 @@ describe('resolveSync', () => {
         resolveSync(relativePath('fixtures'), {
           fileName: 'normal',
         }),
-      ).toThrow(/The specified file does not exist, but a directory exists: /);
+      ).toThrow(/^The specified file does not exist, but a directory exists: /);
     });
   });
 });

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -1,6 +1,6 @@
 import * as path from 'path';
 
-type FixtureType = 'normal' | 'different' | 'nested';
+type FixtureType = 'normal' | 'different' | 'nested' | 'invalid-extends';
 export type FixturesPath = `fixtures/${FixtureType}` | `fixtures/${FixtureType}/${string}`;
 
 export const relativePath = (p: FixturesPath) => path.join(__dirname, p);

--- a/yarn.lock
+++ b/yarn.lock
@@ -611,6 +611,11 @@
   resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
   integrity sha1-7ihweulOEdK4J7y+UnC86n8+ce4=
 
+"@types/just-extend@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@types/just-extend/-/just-extend-1.1.0.tgz#1dae177f58e35721cab85dbc07913b4713d66faa"
+  integrity sha512-vLX87iZxBulJ3dG5vpbM3kWVh8lBK8JCDFD68DaUYHgYGTBL9SqztLG29JLIRbE53ErwlwyaH7jUFxtxUkkTlg==
+
 "@types/node@*":
   version "14.14.20"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-14.14.20.tgz#f7974863edd21d1f8a494a73e8e2b3658615c340"
@@ -3006,6 +3011,11 @@ jsprim@^1.2.2:
     extsprintf "1.3.0"
     json-schema "0.2.3"
     verror "1.10.0"
+
+just-extend@^4.2.1:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/just-extend/-/just-extend-4.2.1.tgz#ef5e589afb61e5d66b24eca749409a8939a8c744"
+  integrity sha512-g3UB796vUFIY90VIv/WX3L2c8CS2MdWUww3CNrYmqza1Fg0DURc2K/O4YrnklBdQarSJ/y8JnJYDGc+1iumQjg==
 
 kind-of@^3.0.2, kind-of@^3.0.3, kind-of@^3.2.0:
   version "3.2.2"


### PR DESCRIPTION
## TODOs

- [x] enable `extends` option
- [x] ~~imitate behavior of resolving `extends` prop~~
    - ~~`include`, `exclude` and `files` prop~~
    - → #3
- [x] ~~resolve path to npm package~~
    - → #5
- test cases
    - [x] `recursive` option is set to `true`/`false`
    - [x] `extends` option is set to `true`/`false`
    - [x] multiple extended config files

## reference
- [TypeScript: TSConfig Reference - Docs on every TSConfig option](https://www.typescriptlang.org/tsconfig#extends)